### PR TITLE
Add new basic services from service generation ('0 A.D.', False) to ('Antville', True)

### DIFF
--- a/greyhoundDashboard/services/basic_services/service_alfrescoCommunityEdition.py
+++ b/greyhoundDashboard/services/basic_services/service_alfrescoCommunityEdition.py
@@ -1,0 +1,20 @@
+from services.service_base import ServiceBase
+
+class ServiceAlfrescoCommunityEdition(ServiceBase):
+    """
+    Alfresco Community Edition
+    
+    """
+    id: str = 'alfrescoCommunityEdition'
+    name: str = 'Alfresco Community Edition'
+    description: str = 'An open-source Enterprise Content Management (ECM) system that manages all the content within an enterprise and provides the services and controls that manage this content.'
+    tags: list[str] = ['content management', 'open-source', 'enterprise', 'ECM']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Alfresco Community Edition is a web application
+        web_app = True
+        return super().render()

--- a/greyhoundDashboard/services/basic_services/service_algernon.py
+++ b/greyhoundDashboard/services/basic_services/service_algernon.py
@@ -1,0 +1,24 @@
+from services.service_base import ServiceBase
+
+class ServiceAlgernon(ServiceBase):
+    """
+    Algernon is a web server with built-in support for QUIC, HTTP/2, Lua, Teal, Markdown, Pongo2, HyperApp, Amber, Sass(SCSS), GCSS, JSX, Ollama (LLMs), BoltDB, Redis, PostgreSQL, MariaDB/MySQL, MSSQL, rate limiting, graceful shutdown, plugins, users, and permissions.
+    
+    """
+    id: str = 'algernon'
+    name: str = 'Algernon'
+    description: str = 'A web server with built-in support for QUIC, HTTP/2, Lua, Teal, Markdown, Pongo2, HyperApp, Amber, Sass(SCSS), GCSS, JSX, Ollama (LLMs), BoltDB, Redis, PostgreSQL, MariaDB/MySQL, MSSQL, rate limiting, graceful shutdown, plugins, users, and permissions.'
+    tags: list[str] = ['web server', 'QUIC', 'HTTP/2', 'Lua', 'Teal', 'Markdown', 'Pongo2', 'HyperApp', 'Amber', 'Sass', 'GCSS', 'JSX', 'Ollama', 'BoltDB', 'Redis', 'PostgreSQL', 'MariaDB', 'MySQL', 'MSSQL', 'rate limiting', 'graceful shutdown', 'plugins', 'users', 'permissions']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Custom rendering logic for Algernon can be added here
+        return super().render()
+
+    @classmethod
+    def register(cls) -> None:
+        super().register()
+        # Additional registration logic for Algernon can be added here

--- a/greyhoundDashboard/services/basic_services/service_aliasvault.py
+++ b/greyhoundDashboard/services/basic_services/service_aliasvault.py
@@ -1,0 +1,34 @@
+from services.service_base import ServiceBase
+
+class ServiceAliasVault(ServiceBase):
+    """
+    🔐 AliasVault
+    """
+    id: str = 'aliasvault'
+    name: str = 'AliasVault'
+    description: str = 'An end-to-end encrypted password and email alias manager that protects your privacy by creating alternative identities, passwords, and email addresses for every website you use.'
+    tags: list[str] = ['password manager', 'email alias', 'privacy', 'self-hosted', 'open-source']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Custom rendering logic for AliasVault
+        return super().render()
+
+    @classmethod
+    def register(cls) -> None:
+        super().register()
+
+    @classmethod
+    def is_web_app(cls) -> bool:
+        return True
+
+    @classmethod
+    def logo(cls) -> str:
+        return 'https://www.aliasvault.net/logo.png'
+
+    @classmethod
+    def branch_name(cls) -> str:
+        return 'main'

--- a/greyhoundDashboard/services/basic_services/service_ampache.py
+++ b/greyhoundDashboard/services/basic_services/service_ampache.py
@@ -1,0 +1,23 @@
+from services.service_base import ServiceBase
+
+class ServiceAmpache(ServiceBase):
+    """
+    🎵 Ampache
+    """
+    id: str = 'ampache'
+    name: str = 'Ampache'
+    description: str = 'A web-based audio/video streaming application and file manager, allowing you to access your music and videos from anywhere, using almost any internet-enabled device.'
+    tags: list[str] = ['music streaming', 'media server', 'self-hosted', 'open-source']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Custom rendering logic for Ampache can be added here
+        return super().render()
+
+    @classmethod
+    def register(cls) -> None:
+        super().register()
+        # Additional registration logic for Ampache can be added here

--- a/greyhoundDashboard/services/basic_services/service_amusewiki.py
+++ b/greyhoundDashboard/services/basic_services/service_amusewiki.py
@@ -1,0 +1,24 @@
+from services.service_base import ServiceBase
+
+class ServiceAmusewiki(ServiceBase):
+    """
+    A·Muse·Wiki
+    ([amusewiki.org](https://amusewiki.org/?utm_source=openai))
+    """
+    id: str = 'amusewiki'
+    name: str = 'A·Muse·Wiki'
+    description: str = 'A library-oriented wiki engine and publishing platform that supports high-quality output formats like EPUB and PDF, with a focus on long-term archiving and offline editing.'
+    tags: list[str] = ['wiki engine', 'publishing platform', 'open-source', 'offline editing', 'EPUB', 'PDF']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Override the render method to provide custom rendering logic if needed.
+        return super().render()
+
+    @classmethod
+    def register(cls) -> None:
+        super().register()
+        # Additional registration logic can be added here if necessary.

--- a/greyhoundDashboard/services/basic_services/service_anchr.py
+++ b/greyhoundDashboard/services/basic_services/service_anchr.py
@@ -1,0 +1,24 @@
+from services.service_base import ServiceBase
+
+class ServiceAnchr(ServiceBase):
+    """
+    ⚓️ Anchr
+    """
+    id: str = 'anchr'
+    name: str = 'Anchr'
+    description: str = 'An open-source platform offering bookmark management, image upload, and URL shortening services.'
+    tags: list[str] = ['bookmarking', 'image-upload', 'url-shortening', 'open-source']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Custom rendering logic for Anchr service
+        return super().render()
+
+    @classmethod
+    def register(cls) -> None:
+        super().register()
+        # Additional registration logic for Anchr service
+        pass

--- a/greyhoundDashboard/services/basic_services/service_anonaddy.py
+++ b/greyhoundDashboard/services/basic_services/service_anonaddy.py
@@ -1,0 +1,23 @@
+from services.service_base import ServiceBase
+
+class ServiceAnonAddy(ServiceBase):
+    """
+    🛡️ AnonAddy
+    """
+    id: str = 'anonaddy'
+    name: str = 'AnonAddy'
+    description: str = 'An open-source anonymous email forwarding service that allows users to create unlimited email aliases to protect their real email addresses.'
+    tags: list[str] = ['email', 'privacy', 'security', 'open-source']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Custom rendering logic for AnonAddy can be added here
+        return super().render()
+
+    @classmethod
+    def register(cls) -> None:
+        super().register()
+        # Additional registration logic for AnonAddy can be added here

--- a/greyhoundDashboard/services/basic_services/service_answer.py
+++ b/greyhoundDashboard/services/basic_services/service_answer.py
@@ -1,0 +1,24 @@
+from services.service_base import ServiceBase
+
+class ServiceAnswer(ServiceBase):
+    """
+    Answer is an open-source knowledge-based community software designed to help you quickly build your Q&A community for product technical support, customer support, user communication, and more.
+    ([facts.dev](https://www.facts.dev/p/answer/?utm_source=openai))
+    It offers features like visit activity tracking, conversation performance metrics, and a comprehensive knowledge base.
+    ([facts.dev](https://www.facts.dev/p/answer/?utm_source=openai))
+    Answer is built with Ruby 2.6+ and PostgreSQL 10+, ensuring robust performance and scalability.
+    ([facts.dev](https://www.facts.dev/p/answer/?utm_source=openai))
+    ️
+    """
+    id: str = 'answer'
+    name: str = 'Answer'
+    description: str = 'An open-source knowledge-based community software designed to help you quickly build your Q&A community for product technical support, customer support, user communication, and more.'
+    tags: list[str] = ['Q&A', 'community', 'open-source', 'knowledge-base']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Custom rendering logic for Answer service
+        return super().render()

--- a/greyhoundDashboard/services/basic_services/service_antville.py
+++ b/greyhoundDashboard/services/basic_services/service_antville.py
@@ -1,0 +1,23 @@
+from services.service_base import ServiceBase
+
+class ServiceAntville(ServiceBase):
+    """
+    🐜 Antville
+    """
+    id: str = 'antville'
+    name: str = 'Antville'
+    description: str = 'An open-source, high-performance weblog hosting system written in server-side JavaScript, capable of hosting tens of thousands of blogs.'
+    tags: list[str] = ['blogging', 'content-management', 'open-source', 'self-hosted']
+
+    def get(self) -> ServiceBase:
+        super().get()
+        return self
+
+    def render(self) -> str:
+        # Custom rendering logic for Antville can be added here
+        return super().render()
+
+    @classmethod
+    def register(cls) -> None:
+        super().register()
+        # Additional registration logic for Antville can be added here

--- a/tooling/awesome_selfhosted_services_completed.json
+++ b/tooling/awesome_selfhosted_services_completed.json
@@ -1,0 +1,182 @@
+{
+  "0AD": {
+    "name": "0 A.D.",
+    "description": "Cross-platform real-time strategy game of ancient warfare.",
+    "homepage": "https://play0ad.com/",
+    "created": false
+  },
+  "2fauth": {
+    "name": "2FAuth",
+    "description": "Manage your Two-Factor Authentication (2FA) accounts and generate their security codes.",
+    "homepage": "https://github.com/Bubka/2FAuth",
+    "created": true
+  },
+  "4gaBoards": {
+    "name": "4ga Boards",
+    "description": "Straightforward realtime kanban boards management for intuitive task tracking. Featuring an elegant dark mode, collapsible todo lists, and multitasking tools to supercharge your team\u00e2\u0080\u0099s productivity.",
+    "homepage": "https://4gaboards.com",
+    "created": true
+  },
+  "aDarkRoom": {
+    "name": "A Dark Room",
+    "description": "Minimalist text adventure game for your browser.",
+    "homepage": "https://github.com/doublespeakgames/adarkroom",
+    "created": true
+  },
+  "accent": {
+    "name": "Accent",
+    "description": "Developer-oriented translation tool.",
+    "homepage": "https://www.accent.reviews/",
+    "created": true
+  },
+  "acpAdmin": {
+    "name": "ACP Admin",
+    "description": "CSA administration. Manage members, subscriptions, deliveries, drop-off locations, member participation, invoices and emails (documentation in French).",
+    "homepage": "https://acp-admin.ch/",
+    "created": true
+  },
+  "activepieces": {
+    "name": "Activepieces",
+    "description": "No-code business automation tool like Zapier or Tray. For example, you can send a Slack notification for each new Trello card.",
+    "homepage": "https://www.activepieces.com",
+    "created": true
+  },
+  "activitywatch": {
+    "name": "ActivityWatch",
+    "description": "Automatically track how you spend time on your devices.",
+    "homepage": "https://activitywatch.net",
+    "created": true
+  },
+  "actual": {
+    "name": "Actual",
+    "description": "Local-first personal finance tool based on zero-sum budgeting, supporting synchronization across devices, custom rules, manual transaction importing (from QIF, OFX, and QFX files), and optional automatic synchronization with many banks.",
+    "homepage": "https://actualbudget.org",
+    "created": true
+  },
+  "adguardHome": {
+    "name": "AdGuard Home",
+    "description": "User-friendly ads & trackers blocking DNS server.",
+    "homepage": "https://adguard.com/en/adguard-home/overview.html",
+    "created": true
+  },
+  "admidio": {
+    "name": "admidio",
+    "description": "User management system for websites of organizations and groups. The system has a flexible role model so that it\u00e2\u0080\u0099s possible to reflect the structure and permissions of your organization.",
+    "homepage": "https://www.admidio.org/",
+    "created": true
+  },
+  "adminer": {
+    "name": "Adminer",
+    "description": "Database management in a single PHP file. Available for MySQL, MariaDB, PostgreSQL, SQLite, MS SQL, Oracle, Elasticsearch, MongoDB and others.",
+    "homepage": "https://www.adminer.org/",
+    "created": true
+  },
+  "adventurelog": {
+    "name": "AdventureLog",
+    "description": "Travel tracker and trip planner.",
+    "homepage": "https://adventurelog.app",
+    "created": true
+  },
+  "affineCommunityEdition": {
+    "name": "AFFiNE Community Edition",
+    "description": "Next-gen knowledge base that brings planning, sorting and creating all together. Privacy first, customizable and ready to use (alternative to Notion and Miro).",
+    "homepage": "https://affine.pro/",
+    "created": true
+  },
+  "aimeos": {
+    "name": "Aimeos",
+    "description": "E-commerce framework for building custom online shops, market places and complex B2B applications scaling to billions of items with Laravel.",
+    "homepage": "https://aimeos.org/",
+    "created": true
+  },
+  "airtrail": {
+    "name": "AirTrail",
+    "description": "Personal flight tracking system.",
+    "homepage": "https://airtrail.johan.ohly.dk",
+    "created": true
+  },
+  "akkoma": {
+    "name": "Akkoma",
+    "description": "Federated microblogging server with Mastodon, GNU social, and ActivityPub compatibility.",
+    "homepage": "https://akkoma.social/",
+    "created": true
+  },
+  "aleph": {
+    "name": "Aleph",
+    "description": "Tool for indexing large amounts of both documents (PDF, Word, HTML) and structured (CSV, XLS, SQL) data for easy browsing and search. It is built with investigative reporting as a primary use case.",
+    "homepage": "https://aleph.occrp.org/",
+    "created": true
+  },
+  "alerthub": {
+    "name": "AlertHub",
+    "description": "Get alerts from GitHub releases.",
+    "homepage": "https://github.com/Ardakilic/alerthub",
+    "created": false
+  },
+  "alfIo": {
+    "name": "Alf.io",
+    "description": "Ticket reservation system.",
+    "homepage": "https://alf.io/",
+    "created": true
+  },
+  "alfrescoCommunityEdition": {
+    "name": "Alfresco Community Edition",
+    "description": "The open source Enterprise Content Management software that handles any type of content, allowing users to easily share and collaborate on content.",
+    "homepage": "https://www.alfresco.com/products/community/download",
+    "created": true
+  },
+  "algernon": {
+    "name": "Algernon",
+    "description": "Small self-contained pure-Go web server with Lua, Markdown, HTTP/2, QUIC, Redis and PostgreSQL support.",
+    "homepage": "https://algernon.roboticoverlords.org/",
+    "created": true
+  },
+  "aliasvault": {
+    "name": "AliasVault",
+    "description": "End-to-end encrypted password manager with a built-in email alias generator and server.",
+    "homepage": "https://www.aliasvault.net",
+    "created": true
+  },
+  "ampache": {
+    "name": "Ampache",
+    "description": "Web based audio/video streaming application.",
+    "homepage": "https://ampache.org/",
+    "created": true
+  },
+  "amusewiki": {
+    "name": "AmuseWiki",
+    "description": "Amusewiki is based on the Emacs Muse markup, remaining mostly compatible with the original implementation. It can work as a read-only site, as a moderated wiki, or as a fully open wiki or even as a private site.",
+    "homepage": "https://amusewiki.org/",
+    "created": true
+  },
+  "anchr": {
+    "name": "Anchr",
+    "description": "Toolbox for tiny tasks on the internet, including bookmark collections, URL shortening and (encrypted) image uploads.",
+    "homepage": "https://anchr.io",
+    "created": true
+  },
+  "anonaddy": {
+    "name": "AnonAddy",
+    "description": "Email forwarding service for creating aliases.",
+    "homepage": "https://anonaddy.com",
+    "created": true
+  },
+  "ansibleNas": {
+    "name": "Ansible-NAS",
+    "description": "Build a full-featured home server with this playbook and an Ubuntu box.",
+    "homepage": "https://github.com/DaveStephens/ansible-nas",
+    "created": false
+  },
+  "answer": {
+    "name": "Answer",
+    "description": "Knowledge-based community software. You can use it to quickly build your Q&A community for product technical support, customer support, user communication, and more.",
+    "homepage": "https://answer.dev/",
+    "created": true
+  },
+  "antville": {
+    "name": "Antville",
+    "description": "Free, open source project aimed at the development of a high performance, feature rich weblog hosting software.",
+    "homepage": "https://antville.org",
+    "created": true
+  }
+}


### PR DESCRIPTION
This implements the following services:

0 A.D.: False
2FAuth: True
4ga Boards: True
A Dark Room: True
Accent: True
ACP Admin: True
Activepieces: True
ActivityWatch: True
Actual: True
AdGuard Home: True
admidio: True
Adminer: True
AdventureLog: True
AFFiNE Community Edition: True
Aimeos: True
AirTrail: True
Akkoma: True
Aleph: True
AlertHub: False
Alf.io: True
Alfresco Community Edition: True
Algernon: True
AliasVault: True
Ampache: True
AmuseWiki: True
Anchr: True
AnonAddy: True
Ansible-NAS: False
Answer: True
Antville: True